### PR TITLE
Updated PHPSecLib from 0.3.x to 2.X.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": ">=5.5.9",
     "illuminate/support": "5.1.*",
     "illuminate/filesystem": "5.1.*",
-    "phpseclib/phpseclib": "0.3.*"
+    "phpseclib/phpseclib": "^2.0"
   },
   "require-dev": {
     "illuminate/console": "5.1.*",

--- a/config/remote.php
+++ b/config/remote.php
@@ -1,49 +1,56 @@
 <?php
 
-    return [
-        /*
-        |--------------------------------------------------------------------------
-        | Default Remote Connection Name
-        |--------------------------------------------------------------------------
-        |
-        | Here you may specify the default connection that will be used for SSH
-        | operations. This name should correspond to a connection name below
-        | in the server list. Each connection will be manually accessible.
-        |
-        */
-        'default'     => 'production',
-        /*
-        |--------------------------------------------------------------------------
-        | Remote Server Connections
-        |--------------------------------------------------------------------------
-        |
-        | These are the servers that will be accessible via the SSH task runner
-        | facilities of Laravel. This feature radically simplifies executing
-        | tasks on your servers, such as deploying out these applications.
-        |
-        */
-        'connections' => [
-            'production' => [
-                'host'      => '',
-                'username'  => '',
-                'password'  => '',
-                'key'       => '',
-                'keytext'   => '',
-                'keyphrase' => '',
-                'agent'     => '',
-            ],
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Remote Connection Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the default connection that will be used for SSH
+    | operations. This name should correspond to a connection name below
+    | in the server list. Each connection will be manually accessible.
+    |
+    */
+
+    'default'     => 'production',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Remote Server Connections
+    |--------------------------------------------------------------------------
+    |
+    | These are the servers that will be accessible via the SSH task runner
+    | facilities of Laravel. This feature radically simplifies executing
+    | tasks on your servers, such as deploying out these applications.
+    |
+    */
+
+    'connections' => [
+        'production' => [
+            'host'      => '',
+            'username'  => '',
+            'password'  => '',
+            'key'       => '',
+            'keytext'   => '',
+            'keyphrase' => '',
+            'agent'     => '',
         ],
-        /*
-        |--------------------------------------------------------------------------
-        | Remote Server Groups
-        |--------------------------------------------------------------------------
-        |
-        | Here you may list connections under a single group name, which allows
-        | you to easily access all of the servers at once using a short name
-        | that is extremely easy to remember, such as "web" or "database".
-        |
-        */
-        'groups'      => [
-            'web' => ['production'],
-        ],
-    ];
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Remote Server Groups
+    |--------------------------------------------------------------------------
+    |
+    | Here you may list connections under a single group name, which allows
+    | you to easily access all of the servers at once using a short name
+    | that is extremely easy to remember, such as "web" or "database".
+    |
+    */
+
+    'groups'      => [
+        'web' => ['production'],
+    ],
+
+];

--- a/phpunit.php
+++ b/phpunit.php
@@ -1,24 +1,28 @@
 <?php
-    /*
-    |--------------------------------------------------------------------------
-    | Register The Composer Auto Loader
-    |--------------------------------------------------------------------------
-    |
-    | Composer provides a convenient, automatically generated class loader
-    | for our application. We just need to utilize it! We'll require it
-    | into the script here so that we do not have to worry about the
-    | loading of any our classes "manually". Feels great to relax.
-    |
-    */
-    require __DIR__.'/vendor/autoload.php';
-    /*
-    |--------------------------------------------------------------------------
-    | Set The Default Timezone
-    |--------------------------------------------------------------------------
-    |
-    | Here we will set the default timezone for PHP. PHP is notoriously mean
-    | if the timezone is not explicitly set. This will be used by each of
-    | the PHP date and date-time functions throughout the application.
-    |
-    */
-    date_default_timezone_set('UTC');
+
+/*
+|--------------------------------------------------------------------------
+| Register The Composer Auto Loader
+|--------------------------------------------------------------------------
+|
+| Composer provides a convenient, automatically generated class loader
+| for our application. We just need to utilize it! We'll require it
+| into the script here so that we do not have to worry about the
+| loading of any our classes "manually". Feels great to relax.
+|
+*/
+
+require __DIR__.'/vendor/autoload.php';
+
+/*
+|--------------------------------------------------------------------------
+| Set The Default Timezone
+|--------------------------------------------------------------------------
+|
+| Here we will set the default timezone for PHP. PHP is notoriously mean
+| if the timezone is not explicitly set. This will be used by each of
+| the PHP date and date-time functions throughout the application.
+|
+*/
+
+date_default_timezone_set('UTC');

--- a/src/RemoteServiceProvider.php
+++ b/src/RemoteServiceProvider.php
@@ -31,6 +31,7 @@ class RemoteServiceProvider extends ServiceProvider
 
         $this->registerCommands();
     }
+
     /**
      * Register the service provider.
      *
@@ -68,6 +69,7 @@ class RemoteServiceProvider extends ServiceProvider
             return new TailCommand();
         });
     }
+
     /**
      * Get the services provided by the provider.
      *

--- a/src/SecLibGateway.php
+++ b/src/SecLibGateway.php
@@ -2,10 +2,11 @@
 
 namespace Collective\Remote;
 
-use Crypt_RSA;
 use Illuminate\Filesystem\Filesystem;
-use Net_SFTP;
-use System_SSH_Agent;
+use phpseclib\Crypt\RSA;
+use phpseclib\Net\SFTP;
+use phpseclib\Net\SSH2;
+use phpseclib\System\SSH\Agent;
 
 class SecLibGateway implements GatewayInterface
 {
@@ -145,7 +146,7 @@ class SecLibGateway implements GatewayInterface
      */
     public function put($local, $remote)
     {
-        $this->getConnection()->put($remote, $local, NET_SFTP_LOCAL_FILE);
+        $this->getConnection()->put($remote, $local, SFTP::SOURCE_LOCAL_FILE);
     }
 
     /**
@@ -168,7 +169,7 @@ class SecLibGateway implements GatewayInterface
      */
     public function nextLine()
     {
-        $value = $this->getConnection()->_get_channel_packet(NET_SSH2_CHANNEL_EXEC);
+        $value = $this->getConnection()->_get_channel_packet(SSH2::CHANNEL_EXEC);
 
         return $value === true ? null : $value;
     }
@@ -272,21 +273,21 @@ class SecLibGateway implements GatewayInterface
     /**
      * Get a new SSH Agent instance.
      *
-     * @return \System_SSH_Agent
+     * @return \phpseclib\System\SSH\Agent
      */
     public function getAgent()
     {
-        return new System_SSH_Agent();
+        return new Agent();
     }
 
     /**
      * Get a new RSA key instance.
      *
-     * @return \Crypt_RSA
+     * @return \phpseclib\Crypt\RSA
      */
     public function getNewKey()
     {
-        return new Crypt_RSA();
+        return new RSA();
     }
 
     /**
@@ -320,9 +321,9 @@ class SecLibGateway implements GatewayInterface
     }
 
     /**
-     * Get the underlying Net_SFTP connection.
+     * Get the underlying SFTP connection.
      *
-     * @return \Net_SFTP
+     * @return \phpseclib\Net\SFTP
      */
     public function getConnection()
     {
@@ -330,6 +331,6 @@ class SecLibGateway implements GatewayInterface
             return $this->connection;
         }
 
-        return $this->connection = new Net_SFTP($this->host, $this->port);
+        return $this->connection = new SFTP($this->host, $this->port);
     }
 }

--- a/tests/RemoteSecLibTest.php
+++ b/tests/RemoteSecLibTest.php
@@ -1,5 +1,6 @@
 <?php
-    use Mockery as m;
+
+use Mockery as m;
 
 class RemoteSecLibGatewayTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This removes support for PHP4 (already unsupported by the Remote) and adds support for PHP7.

If you attempt to use the remote service provider under PHP7, an exception will be thrown as shown:

    ErrorException: Methods with the same name as their class will not be constructors in a future version of PHP; Net_SFTP has a deprecated constructor

    /remote/vendor/phpseclib/phpseclib/phpseclib/Net/SFTP.php:122
    /remote/src/SecLibGateway.php:333
    /remote/src/SecLibGateway.php:98
    /remote/src/Connection.php:247
    /remote/src/Connection.php:113