### PR TITLE
Finish implementing ConnectionInterface on MultiConnection.

### DIFF
--- a/src/MultiConnection.php
+++ b/src/MultiConnection.php
@@ -97,7 +97,6 @@ class MultiConnection implements ConnectionInterface
         }
     }
 
-
     /**
      * Upload a local file to the server.
      *

--- a/src/MultiConnection.php
+++ b/src/MultiConnection.php
@@ -97,4 +97,47 @@ class MultiConnection implements ConnectionInterface
             $connection->putString($remote, $contents);
         }
     }
+
+    /**
+     * Check whether a given file exists on the server.
+     *
+     * @param string $remote
+     *
+     * @return bool
+     */
+    public function exists($remote)
+    {
+        foreach ($this->connections as $connection) {
+            $connection->exists($remote);
+        }
+    }
+
+    /**
+     * Rename a remote file.
+     *
+     * @param string $remote
+     * @param string $newRemote
+     *
+     * @return bool
+     */
+    public function rename($remote, $newRemote)
+    {
+        foreach ($this->connections as $connection) {
+            $connection->rename($remote, $newRemote);
+        }
+    }
+
+    /**
+     * Delete a remote file from the server.
+     *
+     * @param string $remote
+     *
+     * @return bool
+     */
+    public function delete($remote)
+    {
+        foreach ($this->connections as $connection) {
+            $connection->delete($remote);
+        }
+    }
 }

--- a/src/MultiConnection.php
+++ b/src/MultiConnection.php
@@ -69,6 +69,36 @@ class MultiConnection implements ConnectionInterface
     }
 
     /**
+     * Download the contents of a remote file.
+     *
+     * @param string $remote
+     * @param string $local
+     *
+     * @return void
+     */
+    public function get($remote, $local)
+    {
+        foreach ($this->connections as $connection) {
+            $connection->get($remote, $local);
+        }
+    }
+
+    /**
+     * Get the contents of a remote file.
+     *
+     * @param string $remote
+     *
+     * @return string
+     */
+    public function getString($remote)
+    {
+        foreach ($this->connections as $connection) {
+            $connection->getString($remote);
+        }
+    }
+
+
+    /**
      * Upload a local file to the server.
      *
      * @param string $local


### PR DESCRIPTION
This fixes the following error.

```
exception 'Symfony\Component\Debug\Exception\FatalErrorException' with message 'Class Collective\Remote\MultiConnection contains 5 abstract methods and must therefore be declared abstract or implement the remaining methods (Collective\Remote\ConnectionInterface::get, Collective\Remote\ConnectionInterface::getString, Collective\Remote\ConnectionInterface::exists, ...)'
```