### PR TITLE
Allow to connect to a remote host that's not defined in the config file

### DIFF
--- a/src/Console/TailCommand.php
+++ b/src/Console/TailCommand.php
@@ -126,7 +126,7 @@ class TailCommand extends Command
      */
     protected function getRemote($connection)
     {
-        return $this->laravel[ 'remote' ]->connection($connection);
+        return $this->laravel['remote']->connection($connection);
     }
 
     /**
@@ -160,7 +160,7 @@ class TailCommand extends Command
      */
     protected function getRoot($connection)
     {
-        return $this->laravel[ 'config' ][ 'remote.connections.'.$connection.'.root' ];
+        return $this->laravel['config']['remote.connections.'.$connection.'.root'];
     }
 
     /**

--- a/src/RemoteManager.php
+++ b/src/RemoteManager.php
@@ -58,6 +58,18 @@ class RemoteManager
     }
 
     /**
+     * Make a new connection instance based on passed params.
+     *
+     * @param array  $config
+     *
+     * @return \Collective\Remote\Connection
+     */
+    public function connect($config)
+    {
+        return $this->makeConnection($config['host'], $config);
+    }
+
+    /**
      * Resolve a multiple connection instance.
      *
      * @param array $names

--- a/src/RemoteManager.php
+++ b/src/RemoteManager.php
@@ -60,7 +60,7 @@ class RemoteManager
     /**
      * Make a new connection instance based on passed params.
      *
-     * @param array  $config
+     * @param array $config
      *
      * @return \Collective\Remote\Connection
      */

--- a/src/RemoteServiceProvider.php
+++ b/src/RemoteServiceProvider.php
@@ -7,7 +7,6 @@ use Illuminate\Support\ServiceProvider;
 
 class RemoteServiceProvider extends ServiceProvider
 {
-
     /**
      * The commands to be registered.
      *

--- a/src/RemoteServiceProvider.php
+++ b/src/RemoteServiceProvider.php
@@ -29,9 +29,9 @@ class RemoteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (! $this->isLumen()) {
+        if (!$this->isLumen()) {
             $this->publishes([
-              __DIR__ . '/../config/remote.php' => config_path('remote.php'),
+              __DIR__.'/../config/remote.php' => config_path('remote.php'),
             ]);
         }
 
@@ -39,7 +39,7 @@ class RemoteServiceProvider extends ServiceProvider
     }
 
     /**
-     * Check if package is running under Lumen app
+     * Check if package is running under Lumen app.
      *
      * @return bool
      */


### PR DESCRIPTION
Sometimes, it might be helpful to allow to connect to a host that's not defined in the config file, so I've added a **connect** function that will make a connection base on passed params.