### PR TITLE
upgrade composer.json file to support L54

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "illuminate/support": "5.3.*",
-        "illuminate/filesystem": "5.3.*",
+        "illuminate/support": "5.4.*",
+        "illuminate/filesystem": "5.4.*",
         "phpseclib/phpseclib": "^2.0"
     },
     "require-dev": {
-        "illuminate/console": "5.3.*",
+        "illuminate/console": "5.4.*",
         "mockery/mockery": "~0.9.4",
-        "phpunit/phpunit": "~5.4"
+        "phpunit/phpunit": "~5.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
it now works just with L54, but if it's needed i can set it like this: `"5.3.*|5.4.*"`

and all test are passed
