### PR TITLE
[5.8] Use Str support class instead of helpers

### DIFF
--- a/src/SecLibGateway.php
+++ b/src/SecLibGateway.php
@@ -3,6 +3,7 @@
 namespace Collective\Remote;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 use phpseclib\Crypt\RSA;
 use phpseclib\Net\SFTP;
 use phpseclib\Net\SSH2;
@@ -77,7 +78,7 @@ class SecLibGateway implements GatewayInterface
      */
     protected function setHostAndPort($host)
     {
-        if (!str_contains($host, ':')) {
+        if (!Str::contains($host, ':')) {
             $this->host = $host;
         } else {
             list($this->host, $this->port) = explode(':', $host);


### PR DESCRIPTION
Arr and Str helpers will be removed in laravel 5.9. So, we should use support classes instead of helpers.

https://github.com/laravel/framework/pull/27504