### PR TITLE
Allow to specify timeout when running commands

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -103,16 +103,21 @@ class Connection implements ConnectionInterface
      * Run a set of commands against the connection.
      *
      * @param string|array $commands
-     * @param \Closure     $callback
+     * @param \Closure $callback
      *
+     * @param int|null $timeout
      * @return void
      */
-    public function run($commands, Closure $callback = null)
+    public function run($commands, Closure $callback = null, int $timeout = null)
     {
         // First, we will initialize the SSH gateway, and then format the commands so
         // they can be run. Once we have the commands formatted and the server is
         // ready to go we will just fire off these commands against the server.
         $gateway = $this->getGateway();
+
+        if ($timeout != null) {
+            $gateway->setTimeout($timeout);
+        }
 
         $callback = $this->getCallback($callback);
 
@@ -314,5 +319,12 @@ class Connection implements ConnectionInterface
     public function status()
     {
         return $this->gateway->status();
+    }
+
+    public function setTimeout($timeout) {
+
+        $this->getGateway()->setTimeout($timeout);
+
+        return $this;
     }
 }

--- a/src/GatewayInterface.php
+++ b/src/GatewayInterface.php
@@ -109,4 +109,12 @@ interface GatewayInterface
      * @return int|bool
      */
     public function status();
+
+    /**
+     * Set timeout
+     *
+     * @param $timeout
+     * @return mixed
+     */
+    public function setTimeout($timeout);
 }

--- a/src/SecLibGateway.php
+++ b/src/SecLibGateway.php
@@ -250,9 +250,13 @@ class SecLibGateway implements GatewayInterface
      *
      * @param int $timeout
      */
-    protected function setTimeout($timeout)
+    public function setTimeout($timeout)
     {
         $this->timeout = (int) $timeout;
+
+        if ($this->connection) {
+            $this->connection->setTimeout($this->timeout);
+        }
     }
 
     /**

--- a/tests/RemoteSecLibTest.php
+++ b/tests/RemoteSecLibTest.php
@@ -14,6 +14,7 @@ class RemoteSecLibGatewayTest extends PHPUnit_Framework_TestCase
         $gateway = $this->getGateway();
         $this->assertEquals('127.0.0.1', $gateway->getHost());
         $this->assertEquals(22, $gateway->getPort());
+        $this->assertEquals(10, $gateway->getTimeout());
     }
 
     public function testConnectProperlyCallsLoginWithAuth()
@@ -29,7 +30,7 @@ class RemoteSecLibGatewayTest extends PHPUnit_Framework_TestCase
     public function testKeyTextCanBeSetManually()
     {
         $files = m::mock('Illuminate\Filesystem\Filesystem');
-        $gateway = m::mock('Collective\Remote\SecLibGateway', [
+        $gateway = m::mock('Collective\Remote\SecLibGateway[!setTimeout]', [
                 '127.0.0.1:22',
                 ['username' => 'taylor', 'keytext' => 'keystuff'],
                 $files,
@@ -47,7 +48,7 @@ class RemoteSecLibGatewayTest extends PHPUnit_Framework_TestCase
     {
         $files = m::mock('Illuminate\Filesystem\Filesystem');
         $files->shouldReceive('get')->with('keypath')->andReturn('keystuff');
-        $gateway = m::mock('Collective\Remote\SecLibGateway', [
+        $gateway = m::mock('Collective\Remote\SecLibGateway[!setTimeout]', [
                 '127.0.0.1:22',
                 ['username' => 'taylor', 'key' => 'keypath', 'keyphrase' => 'keyphrase'],
                 $files,


### PR DESCRIPTION
It makes more sense to specify timeout for specific command or set of commands when calling run method, than in config. Different commands on same ssh host can take different time. Although it can be solved by modifying config just before making ssh connection it is not very clean. This way you could run: 
```
SSH::into($server->server_host_name)
    ->run([
        'sleep 15',
        'pwd'
    ], null, 30);
```
and it won't timeout. It should also be backwards compatible so no breaking change AFAIK. Correct me if you could find any drawbacks