### PR TITLE
Suggest same but updated Laravel SSH package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,5 +47,5 @@
         }
     },
     "minimum-stability": "dev",
-    "abandoned": "spatie/ssh"
+    "abandoned": "rocketeers-app/laravel-ssh"
 }


### PR DESCRIPTION
In the abandoned property it's better to suggest a package that works the same, but is upgraded to PHP 8.x and Laravel 8+.