### PR TITLE
Laravel 9, 10 & 11 compatibility + phpseclib v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/support": "^6.0|^7.0|^8.0",
-        "illuminate/filesystem": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/filesystem": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "phpseclib/phpseclib": "^2.0"
     },
     "require-dev": {
-        "illuminate/console": "^6.0|^7.0|^8.0",
+        "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "mockery/mockery": "~1.0",
         "phpunit/phpunit": "~5.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravelcollective/remote",
+    "name": "whitecube/remote",
     "description": "Remote SSH access for The Laravel Framework.",
     "license": "MIT",
     "homepage": "http://laravelcollective.com",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=7.2",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "illuminate/filesystem": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "phpseclib/phpseclib": "^2.0"
+        "phpseclib/phpseclib": "^3.0"
     },
     "require-dev": {
         "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -121,18 +121,7 @@ class Connection implements ConnectionInterface
 
         $callback = $this->getCallback($callback);
 
-        $gateway->run($this->formatCommands($commands));
-
-        // After running the commands against the server, we will continue to ask for
-        // the next line of output that is available, and write it them out using
-        // our callback. Once we hit the end of output, we'll bail out of here.
-        while (true) {
-            if (is_null($line = $gateway->nextLine())) {
-                break;
-            }
-
-            call_user_func($callback, $line, $this);
-        }
+        $gateway->run($this->formatCommands($commands), $callback);
     }
 
     /**

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -119,9 +119,9 @@ class Connection implements ConnectionInterface
             $gateway->setTimeout($timeout);
         }
 
-        $callback = $this->getCallback($callback);
+        $result = $gateway->run($this->formatCommands($commands));
 
-        $gateway->run($this->formatCommands($commands), $callback);
+        call_user_func($this->getCallback($callback), $result);
     }
 
     /**

--- a/src/SecLibGateway.php
+++ b/src/SecLibGateway.php
@@ -280,7 +280,7 @@ class SecLibGateway implements GatewayInterface
      *
      * @param string $command
      *
-     * @return void
+     * @return string|bool
      */
     public function run($command)
     {
@@ -382,9 +382,7 @@ class SecLibGateway implements GatewayInterface
      */
     public function nextLine()
     {
-        $value = $this->getConnection()->open_channel(SSH2::CHANNEL_EXEC);
-
-        return $value === true ? null : $value;
+        return null;
     }
 
     /**

--- a/src/SecLibGateway.php
+++ b/src/SecLibGateway.php
@@ -284,7 +284,7 @@ class SecLibGateway implements GatewayInterface
      */
     public function run($command)
     {
-        $this->getConnection()->exec($command, null);
+        return $this->getConnection()->exec($command, null);
     }
 
     /**

--- a/src/SecLibGateway.php
+++ b/src/SecLibGateway.php
@@ -382,7 +382,7 @@ class SecLibGateway implements GatewayInterface
      */
     public function nextLine()
     {
-        $value = $this->getConnection()->_get_channel_packet(SSH2::CHANNEL_EXEC);
+        $value = $this->getConnection()->open_channel(SSH2::CHANNEL_EXEC);
 
         return $value === true ? null : $value;
     }

--- a/src/SecLibGateway.php
+++ b/src/SecLibGateway.php
@@ -2,12 +2,12 @@
 
 namespace Collective\Remote;
 
-use phpseclib\Net\SFTP;
-use phpseclib\Net\SSH2;
-use phpseclib\Crypt\RSA;
+use phpseclib3\Net\SFTP;
+use phpseclib3\Net\SSH2;
+use phpseclib3\Crypt\RSA;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use phpseclib\System\SSH\Agent;
+use phpseclib3\System\SSH\Agent;
 use Illuminate\Filesystem\Filesystem;
 
 class SecLibGateway implements GatewayInterface

--- a/src/SecLibGateway.php
+++ b/src/SecLibGateway.php
@@ -284,7 +284,7 @@ class SecLibGateway implements GatewayInterface
      */
     public function run($command)
     {
-        $this->getConnection()->exec($command, false);
+        $this->getConnection()->exec($command, null);
     }
 
     /**


### PR DESCRIPTION
Hi there,

We're aware this package is abandoned in favor of `spatie/ssh`, but since this repository still offers more configuration options we're still using it for some older projects.

This PR's main objective is to bump `phpseclib` to the current v3. For our usage, this PR is working fine, but there is one breaking change you should be aware of (due to `phpseclib`'s upgrade): the callback passed to `run($commands, $callback)` is no longer called line per line, it is now called after the whole command output has been received.

Hope this PR will be accepted in case other developers still prefer this package over Spatie's simpler solution.

Thanks!

_Superseeds #86, #88 & #92_
